### PR TITLE
Wilson/phase1 delete doc

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,6 +97,11 @@ def delete_embeddings_for_document():
     """Delete all embeddings for DOCUMENT_ID from Aurora."""
     print(f"[DELETE] Deleting embeddings for: {DOCUMENT_ID}")
 
+    embed_model = BedrockEmbedding(
+        model_name="amazon.titan-embed-text-v2:0",
+        region_name="us-east-1",
+    )
+
     vector_store = PGVectorStore.from_params(
         database=DB_NAME,
         host=DB_HOST,
@@ -110,7 +115,7 @@ def delete_embeddings_for_document():
     )
 
     from llama_index.core import VectorStoreIndex
-    index = VectorStoreIndex.from_vector_store(vector_store=vector_store)
+    index = VectorStoreIndex.from_vector_store(vector_store=vector_store, embed_model=embed_model)
 
     try:
         # LlamaIndex built-in deletion by ref_doc_id


### PR DESCRIPTION
  -  Added EVENT_TYPE env var with default "Object Created" (line 46)
  -  Set doc.id_ = DOCUMENT_ID for LlamaIndex delete tracking (lines
  114-116)
  -  Added delete_embeddings_for_document() function (lines 96-134)
    - Uses LlamaIndex delete_ref_doc() with SQL fallback
  - Modified main_with_status() to handle both create and delete events
  (lines 201-247)
    - Detects EVENT_TYPE, routes to delete or create flow
    - Status transitions: deleting → deleted or delete_failed